### PR TITLE
Remove duplicates in "repos" for update_available

### DIFF
--- a/src/_gentoo_packages
+++ b/src/_gentoo_packages
@@ -153,6 +153,7 @@ _gentoo_packages_update_available_pkgnames_only(){
 
 _gentoo_packages_update_available(){
   local repos category packages pkg expl
+  typeset -U repos
 
   repos=($(_gentoo_repos))
   category=($repos/*-*(/:t))


### PR DESCRIPTION
Since switching to repos.conf, completion of available packages has become unbearably slow.
I did a bit of debugging, and the reason is that `_gentoo_repos` returns quite a few duplicates,
resulting in multiple globbing searches through the portage tree and overlays.

This change is the easiest fix I found, although it does not fix the problem at the root.