### PR TITLE
_gentoolkit: add missing equery arg -N or --no-pipe

### DIFF
--- a/src/_gentoolkit
+++ b/src/_gentoolkit
@@ -59,6 +59,7 @@ _equery () {
 
   start_args=(
     {'(--nocolor)-C','(-C)--nocolor'}'[turns off colors]'
+    {'(--no-pipe)-N','(-N)--no-pipe'}'[turn off pipe detection]'
     {'(--quiet)-q','(-q)--quiet'}'[minimal output]'
     {'(--help)-h','(-h)--help'}'[show help]'
     {'(--version)-V','(-V)--version'}'[show version]'


### PR DESCRIPTION
fix Zsh can't complete when use -N option.